### PR TITLE
Add emptiness check for is_overdue()

### DIFF
--- a/catalog/models.py
+++ b/catalog/models.py
@@ -84,7 +84,7 @@ class BookInstance(models.Model):
     
     @property
     def is_overdue(self):
-        if date.today() > self.due_back:
+        if self.due_back and date.today() > self.due_back:
             return True
         return False
         


### PR DESCRIPTION
Without this check, having an empty due_back value on a book instance will cause a TypeError during comparison.