### PR TITLE
Change Book and BookInstance relationship

### DIFF
--- a/catalog/models.py
+++ b/catalog/models.py
@@ -77,7 +77,7 @@ class BookInstance(models.Model):
     Model representing a specific copy of a book (i.e. that can be borrowed from the library).
     """
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, help_text="Unique ID for this particular book across whole library")
-    book = models.ForeignKey('Book', on_delete=models.SET_NULL, null=True) 
+    book = models.ForeignKey('Book', on_delete=models.CASCADE, null=True) 
     imprint = models.CharField(max_length=200)
     due_back = models.DateField(null=True, blank=True)
     borrower = models.ForeignKey(User, on_delete=models.SET_NULL, null=True, blank=True)


### PR DESCRIPTION
If a book is deleted then its all instances are set to null. This gives an error when we query book instances in _all borrowed_ link.