### PR TITLE
Fixes borrower and due_date rendering issue in book_renew_librarian.html

### DIFF
--- a/catalog/views.py
+++ b/catalog/views.py
@@ -86,7 +86,7 @@ from catalog.forms import RenewBookForm
 @permission_required('catalog.can_mark_returned')
 def renew_book_librarian(request, pk):
     """View function for renewing a specific BookInstance by librarian."""
-    book_instance = get_object_or_404(BookInstance, pk = pk)
+    book_instance = get_object_or_404(BookInstance, pk = pk)[0]
 
     # If this is a POST request then process the Form data
     if request.method == 'POST':


### PR DESCRIPTION
Django version I'm using is _2.1.4_. For me, the following code returns a list, instead of BookInstance object. The first index is BookInstance. 

```python
book_instance = get_list_or_404(BookInstance, pk=pk)
```

This creates an issue while rendering. The template expects `book_instance` to be `BookInstance` object. Which is not in this case. 

This can be fixed by getting the first index while declaring `book_instance` variable.

