### PR TITLE
Add online playground to README

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,12 @@
+ports:
+- port: 8080
+  onOpen: open-preview
+tasks:
+- init: >
+    python3 -m pip install -r requirements.txt &&
+    python3 manage.py migrate
+  command: >
+    echo "from locallibrary.settings import *" > locallibrary/local_settings.py &&
+    echo "ALLOWED_HOSTS = ['*']" >> locallibrary/local_settings.py &&
+    export DJANGO_SETTINGS_MODULE=locallibrary.local_settings &&
+    python3 manage.py runserver 0.0.0.0:8080

--- a/README.md
+++ b/README.md
@@ -36,3 +36,7 @@ To get this project up and running locally on your computer:
 1. Open a browser to `http://127.0.0.1:8000/admin/` to open the admin site
 1. Create a few test objects of each type.
 1. Open tab to `http://127.0.0.1:8000` to see the main site, with your new objects.
+
+Alternatively, you can also build and run this application in a pre-configured online workspace:
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/mdn/django-locallibrary-tutorial)


### PR DESCRIPTION
Hello! Thanks for the up-to-date Django tutorial!

This PR adds a Gitpod config and a button, that allows to open a dev environment for this tutorial in the browser. It will start a container with a shell in the cloud and provide a VS Code based IDE running in the browser. I configured it so it automatically installs all required packages.

This is a complementary way of trying out the tutorial right away. Here is what it looks like:

<a href="https://gitpod.io/#https://github.com/mdn/django-locallibrary-tutorial"><img src="https://camo.githubusercontent.com/1eb1ddfea6092593649f0117f7262ffa8fbd3017/68747470733a2f2f676974706f642e696f2f627574746f6e2f6f70656e2d696e2d676974706f642e737667"></a>

<img width="1652" alt="Screen Shot 2019-03-27 at 10 36 13" src="https://user-images.githubusercontent.com/914497/55067726-82159800-5080-11e9-90c9-305566161168.png">


