### PR TITLE
Remove <script> tags linking to JavaScript code

### DIFF
--- a/catalog/templates/base_generic.html
+++ b/catalog/templates/base_generic.html
@@ -6,9 +6,6 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
-  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  
   <!-- Add additional CSS in static file -->
   {% load static %}
   <link rel="stylesheet" href="{% static 'css/styles.css' %}">


### PR DESCRIPTION
Remove <script> tags linking to JavaScript code.  These are extra lines which are not used in [the tutorial](https://developer.mozilla.org/en-US/docs/Learn/Server-side/Django/Home_page).