### PR TITLE
Replace fields __all__ in modelview

### DIFF
--- a/catalog/views.py
+++ b/catalog/views.py
@@ -132,7 +132,7 @@ from .models import Author
 class AuthorCreate(PermissionRequiredMixin, CreateView):
     model = Author
     fields = '__all__'
-    initial = {'date_of_death': '05/01/2018'}
+    initial = {'date_of_death': '11/06/2020'}
     permission_required = 'catalog.can_mark_returned'
 
 
@@ -151,13 +151,13 @@ class AuthorDelete(PermissionRequiredMixin, DeleteView):
 # Classes created for the forms challenge
 class BookCreate(PermissionRequiredMixin, CreateView):
     model = Book
-    fields = '__all__'
+    fields = ['title', 'author', 'summary', 'isbn', 'genre', 'language']
     permission_required = 'catalog.can_mark_returned'
 
 
 class BookUpdate(PermissionRequiredMixin, UpdateView):
     model = Book
-    fields = '__all__'
+    fields = ['title', 'author', 'summary', 'isbn', 'genre', 'language']
     permission_required = 'catalog.can_mark_returned'
 
 

--- a/catalog/views.py
+++ b/catalog/views.py
@@ -131,7 +131,7 @@ from .models import Author
 
 class AuthorCreate(PermissionRequiredMixin, CreateView):
     model = Author
-    fields = '__all__'
+    fields = '__all__' # Use of __all__ is potential security issue if more fields added
     initial = {'date_of_death': '11/06/2020'}
     permission_required = 'catalog.can_mark_returned'
 

--- a/catalog/views.py
+++ b/catalog/views.py
@@ -131,14 +131,14 @@ from .models import Author
 
 class AuthorCreate(PermissionRequiredMixin, CreateView):
     model = Author
-    fields = '__all__' # Use of __all__ is potential security issue if more fields added
+    fields = ['first_name', 'last_name', 'date_of_birth', 'date_of_death']
     initial = {'date_of_death': '11/06/2020'}
     permission_required = 'catalog.can_mark_returned'
 
 
 class AuthorUpdate(PermissionRequiredMixin, UpdateView):
     model = Author
-    fields = ['first_name', 'last_name', 'date_of_birth', 'date_of_death']
+    fields = '__all__' # Not recommended (potential security issue if more fields added)
     permission_required = 'catalog.can_mark_returned'
 
 


### PR DESCRIPTION
As per #68 the use of __all__ for fields is not recommended. This fixes the code so that only one instance exists in our code (for demo purposes).