### PR TITLE
Fix up tests and permissions on RenewBookInstancesViewTest

### DIFF
--- a/catalog/tests/test_views.py
+++ b/catalog/tests/test_views.py
@@ -231,13 +231,11 @@ class RenewBookInstancesViewTest(TestCase):
         self.assertEqual(response.status_code, 302)
         self.assertTrue(response.url.startswith('/accounts/login/'))
 
-    def test_redirect_if_logged_in_but_not_correct_permission(self):
+    def test_forbidden_if_logged_in_but_not_correct_permission(self):
         login = self.client.login(username='testuser1', password='1X<ISRUkw+tuK')
         response = self.client.get(reverse('renew-book-librarian', kwargs={'pk': self.test_bookinstance1.pk}))
+        self.assertEqual(response.status_code, 403)
 
-        # Manually check redirect (Can't use assertRedirect, because the redirect URL is unpredictable)
-        self.assertEqual(response.status_code, 302)
-        self.assertTrue(response.url.startswith('/accounts/login/'))
 
     def test_logged_in_with_permission_borrowed_book(self):
         login = self.client.login(username='testuser2', password='2HJ1vRV0Z&3iD')
@@ -324,7 +322,7 @@ class AuthorCreateViewTest(TestCase):
         response = self.client.get(reverse('author_create'))
         self.assertRedirects(response, '/accounts/login/?next=/catalog/author/create/')
 
-    def test_redirect_if_logged_in_but_not_correct_permission(self):
+    def test_forbidden_if_logged_in_but_not_correct_permission(self):
         login = self.client.login(username='testuser1', password='1X<ISRUkw+tuK')
         response = self.client.get(reverse('author_create'))
         self.assertEqual(response.status_code, 403)
@@ -345,7 +343,7 @@ class AuthorCreateViewTest(TestCase):
         response = self.client.get(reverse('author_create'))
         self.assertEqual(response.status_code, 200)
 
-        expected_initial_date = datetime.date(2018, 1, 5)
+        expected_initial_date = datetime.date(2020, 6, 11)
         response_date = response.context['form'].initial['date_of_death']
         response_date = datetime.datetime.strptime(response_date, "%d/%m/%Y").date()
         self.assertEqual(response_date, expected_initial_date)

--- a/catalog/views.py
+++ b/catalog/views.py
@@ -85,13 +85,14 @@ from django.shortcuts import get_object_or_404
 from django.http import HttpResponseRedirect
 from django.urls import reverse
 import datetime
-from django.contrib.auth.decorators import permission_required
+from django.contrib.auth.decorators import login_required, permission_required
 
 # from .forms import RenewBookForm
 from catalog.forms import RenewBookForm
 
 
-@permission_required('catalog.can_mark_returned')
+@login_required
+@permission_required('catalog.can_mark_returned', raise_exception=True)
 def renew_book_librarian(request, pk):
     """View function for renewing a specific BookInstance by librarian."""
     book_instance = get_object_or_404(BookInstance, pk=pk)


### PR DESCRIPTION
The test case for `RenewBookInstancesViewTest.test_redirect_if_logged_in_but_not_correct_permission` was returning 302 and redirecting to login URL. This is inconsistent vs the Author create and "logic" - i.e.:
- if you aren't logged in you go to a login URL, 
- if you are logged in and you don't have permission you go to a 403 (forbidden)

This sets permissions correctly for the above and fixes the tests to match it. 

Fixes https://github.com/mdn/django-locallibrary-tutorial/issues/66