### PR TITLE
Use Django's built-in template pluralization

### DIFF
--- a/catalog/templates/index.html
+++ b/catalog/templates/index.html
@@ -27,6 +27,6 @@
 </ul>
 
 
-You have visited this page {{ num_visits }} time{% if num_visits > 1 %}s{% endif %}.
+<p>You have visited this page {{ num_visits }} time{{ num_visits|pluralize }}.</p>
 
 {% endblock %}


### PR DESCRIPTION
This might be a good opportunity to tell starters about the built-in pluralization feature of Django (https://docs.djangoproject.com/en/3.1/ref/templates/builtins/#pluralize). It's also used in the original Django tutorial in chapter 4 (https://docs.djangoproject.com/en/3.0/intro/tutorial04/).

If this change is adopted, the [tutorial example code](https://github.com/mdn/content/blob/1422bad91f064cfaaeea6bb32fd38e54037d0c56/files/en-us/learn/server-side/django/sessions/index.html#L162) would also have to be updated accordingly.