### PR TITLE
Book detail get author using get_absolute_url

### DIFF
--- a/catalog/templates/catalog/book_detail.html
+++ b/catalog/templates/catalog/book_detail.html
@@ -4,7 +4,7 @@
 
 <h1>Title: {{ book.title }}</h1>
 
-<p><strong>Author:</strong> <a href="{% url 'author-detail' book.author.pk %}">{{ book.author }}</a></p>
+<p><strong>Author:</strong> <a href="{{ book.author.get_absolute_url }}">{{ book.author }}</a></p>
 <p><strong>Summary:</strong> {{ book.summary }}</p>
 <p><strong>ISBN:</strong> {{ book.isbn }}</p> 
 <p><strong>Language:</strong> {{ book.language }}</p>  


### PR DESCRIPTION
In book_detail.html template use get_absolute_url to get the author detail page url rather than reversing the URL.

Both ways work fine. The benefit of get_absolute_url is that it allows you to define the method in a standard way in your model. Later on you could could change the way the URL works everywhere without having to change any templates. It also allows you to make all templates look the same.

Part of fixing https://github.com/mdn/content/issues/4112