### PR TITLE
Remove Django3 deprecations

### DIFF
--- a/catalog/forms.py
+++ b/catalog/forms.py
@@ -1,5 +1,5 @@
 from django.core.exceptions import ValidationError
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 import datetime  # for checking renewal date range.
 
 from django import forms

--- a/catalog/tests/test_models.py
+++ b/catalog/tests/test_models.py
@@ -15,40 +15,40 @@ class AuthorModelTest(TestCase):
     def test_first_name_label(self):
         author = Author.objects.get(id=1)
         field_label = author._meta.get_field('first_name').verbose_name
-        self.assertEquals(field_label, 'first name')
+        self.assertEqual(field_label, 'first name')
 
     def test_last_name_label(self):
         author = Author.objects.get(id=1)
         field_label = author._meta.get_field('last_name').verbose_name
-        self.assertEquals(field_label, 'last name')
+        self.assertEqual(field_label, 'last name')
 
     def test_date_of_birth_label(self):
         author = Author.objects.get(id=1)
         field_label = author._meta.get_field('date_of_birth').verbose_name
-        self.assertEquals(field_label, 'date of birth')
+        self.assertEqual(field_label, 'date of birth')
 
     def test_date_of_death_label(self):
         author = Author.objects.get(id=1)
         field_label = author._meta.get_field('date_of_death').verbose_name
-        self.assertEquals(field_label, 'died')
+        self.assertEqual(field_label, 'died')
 
     def test_first_name_max_length(self):
         author = Author.objects.get(id=1)
         max_length = author._meta.get_field('first_name').max_length
-        self.assertEquals(max_length, 100)
+        self.assertEqual(max_length, 100)
 
     def test_last_name_max_length(self):
         author = Author.objects.get(id=1)
         max_length = author._meta.get_field('last_name').max_length
-        self.assertEquals(max_length, 100)
+        self.assertEqual(max_length, 100)
 
     def test_object_name_is_last_name_comma_first_name(self):
         author = Author.objects.get(id=1)
         expected_object_name = '{0}, {1}'.format(author.last_name, author.first_name)
 
-        self.assertEquals(str(author), expected_object_name)
+        self.assertEqual(str(author), expected_object_name)
 
     def test_get_absolute_url(self):
         author = Author.objects.get(id=1)
         # This will also fail if the urlconf is not defined.
-        self.assertEquals(author.get_absolute_url(), '/catalog/author/1')
+        self.assertEqual(author.get_absolute_url(), '/catalog/author/1')


### PR DESCRIPTION
Django 3 deprecated features are removed in Django 4, and in any case, are deprecated. This removes the features in preparation for update. It is matched by https://github.com/mdn/content/pull/13200