### PR TITLE
Expand tutorial to allow proper deletion code

### DIFF
--- a/catalog/models.py
+++ b/catalog/models.py
@@ -138,4 +138,4 @@ class Author(models.Model):
 
     def __str__(self):
         """String for representing the Model object."""
-        return '{0}, {1}'.format(self.last_name, self.first_name)
+        return f'{self.last_name}, {self.first_name}'

--- a/catalog/models.py
+++ b/catalog/models.py
@@ -119,7 +119,7 @@ class BookInstance(models.Model):
 
     def __str__(self):
         """String for representing the Model object."""
-        return '{0} ({1})'.format(self.id, self.book.title)
+        return f'{self.id} ({self.book.title})'
 
 
 class Author(models.Model):

--- a/catalog/models.py
+++ b/catalog/models.py
@@ -9,8 +9,9 @@ class Genre(models.Model):
     """Model representing a book genre (e.g. Science Fiction, Non Fiction)."""
     name = models.CharField(
         max_length=200,
+        unique=True,
         help_text="Enter a book genre (e.g. Science Fiction, French Poetry etc.)"
-        )
+    )
 
     def get_absolute_url(self):
         """Returns the url to access a particular genre instance."""
@@ -24,6 +25,7 @@ class Genre(models.Model):
 class Language(models.Model):
     """Model representing a Language (e.g. English, French, Japanese, etc.)"""
     name = models.CharField(max_length=200,
+                            unique=True,
                             help_text="Enter the book's natural language (e.g. English, French, Japanese etc.)")
 
     def get_absolute_url(self):
@@ -38,18 +40,21 @@ class Language(models.Model):
 class Book(models.Model):
     """Model representing a book (but not a specific copy of a book)."""
     title = models.CharField(max_length=200)
-    author = models.ForeignKey('Author', on_delete=models.SET_NULL, null=True)
-    # Foreign Key used because book can only have one author, but authors can have multiple books
+    author = models.ForeignKey('Author', on_delete=models.RESTRICT, null=True)
+    # Foreign Key used because book can only have one author, but authors can have multiple books.
     # Author as a string rather than object because it hasn't been declared yet in file.
-    summary = models.TextField(max_length=1000, help_text="Enter a brief description of the book")
+    summary = models.TextField(
+        max_length=1000, help_text="Enter a brief description of the book")
     isbn = models.CharField('ISBN', max_length=13,
                             unique=True,
                             help_text='13 Character <a href="https://www.isbn-international.org/content/what-isbn'
                                       '">ISBN number</a>')
-    genre = models.ManyToManyField(Genre, help_text="Select a genre for this book")
+    genre = models.ManyToManyField(
+        Genre, help_text="Select a genre for this book")
     # ManyToManyField used because a genre can contain many books and a Book can cover many genres.
     # Genre class has already been defined so we can specify the object above.
-    language = models.ForeignKey('Language', on_delete=models.SET_NULL, null=True)
+    language = models.ForeignKey(
+        'Language', on_delete=models.SET_NULL, null=True)
 
     class Meta:
         ordering = ['title', 'author']
@@ -82,7 +87,8 @@ class BookInstance(models.Model):
     book = models.ForeignKey('Book', on_delete=models.RESTRICT, null=True)
     imprint = models.CharField(max_length=200)
     due_back = models.DateField(null=True, blank=True)
-    borrower = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.SET_NULL, null=True, blank=True)
+    borrower = models.ForeignKey(
+        settings.AUTH_USER_MODEL, on_delete=models.SET_NULL, null=True, blank=True)
 
     @property
     def is_overdue(self):

--- a/catalog/models.py
+++ b/catalog/models.py
@@ -12,6 +12,10 @@ class Genre(models.Model):
         help_text="Enter a book genre (e.g. Science Fiction, French Poetry etc.)"
         )
 
+    def get_absolute_url(self):
+        """Returns the url to access a particular genre instance."""
+        return reverse('genre-detail', args=[str(self.id)])
+
     def __str__(self):
         """String for representing the Model object (in Admin site etc.)"""
         return self.name
@@ -21,6 +25,10 @@ class Language(models.Model):
     """Model representing a Language (e.g. English, French, Japanese, etc.)"""
     name = models.CharField(max_length=200,
                             help_text="Enter the book's natural language (e.g. English, French, Japanese etc.)")
+
+    def get_absolute_url(self):
+        """Returns the url to access a particular language instance."""
+        return reverse('language-detail', args=[str(self.id)])
 
     def __str__(self):
         """String for representing the Model object (in Admin site etc.)"""
@@ -42,7 +50,7 @@ class Book(models.Model):
     # ManyToManyField used because a genre can contain many books and a Book can cover many genres.
     # Genre class has already been defined so we can specify the object above.
     language = models.ForeignKey('Language', on_delete=models.SET_NULL, null=True)
-    
+
     class Meta:
         ordering = ['title', 'author']
 
@@ -53,7 +61,7 @@ class Book(models.Model):
     display_genre.short_description = 'Genre'
 
     def get_absolute_url(self):
-        """Returns the url to access a particular book instance."""
+        """Returns the url to access a particular book record."""
         return reverse('book-detail', args=[str(self.id)])
 
     def __str__(self):
@@ -98,6 +106,10 @@ class BookInstance(models.Model):
     class Meta:
         ordering = ['due_back']
         permissions = (("can_mark_returned", "Set book as returned"),)
+
+    def get_absolute_url(self):
+        """Returns the url to access a particular book instance."""
+        return reverse('bookinstance-detail', args=[str(self.id)])
 
     def __str__(self):
         """String for representing the Model object."""

--- a/catalog/templates/base_generic.html
+++ b/catalog/templates/base_generic.html
@@ -5,8 +5,7 @@
   {% block title %}<title>Local Library</title>{% endblock %}
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
-
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
 
   <!-- Add additional CSS in static file -->
   {% load static %}

--- a/catalog/templates/base_generic.html
+++ b/catalog/templates/base_generic.html
@@ -30,7 +30,7 @@
   <ul class="sidebar-nav">
    {% if user.is_authenticated %}
      <li>User: {{ user.get_username }}</li>
-     <li><a href="{% url 'my-borrowed' %}">My Borrowed</a></li>
+     <li><a href="{% url 'my-borrowed' %}">My borrowed</a></li>
      <li><a href="{% url 'logout'%}?next={{request.path}}">Logout</a></li>
    {% else %}
      <li><a href="{% url 'login'%}?next={{request.path}}">Login</a></li>
@@ -43,11 +43,11 @@
    <li>Staff</li>
    {% if perms.catalog.can_mark_returned %}
    <li><a href="{% url 'all-borrowed' %}">All borrowed</a></li>
-   <li><a href="{% url 'genre-create' %}">Create Genre</a></li>
-   <li><a href="{% url 'language-create' %}">Create Language</a></li>
-   <li><a href="{% url 'author-create' %}">Create Author</a></li>
-   <li><a href="{% url 'book-create' %}">Create Book</a></li>
-   <li><a href="{% url 'bookinstance-create' %}">Create BookInstance</a></li>
+   <li><a href="{% url 'genre-create' %}">Create genre</a></li>
+   <li><a href="{% url 'language-create' %}">Create language</a></li>
+   <li><a href="{% url 'author-create' %}">Create author</a></li>
+   <li><a href="{% url 'book-create' %}">Create book</a></li>
+   <li><a href="{% url 'bookinstance-create' %}">create BookInstance</a></li>
    {% endif %}
 
 
@@ -77,8 +77,6 @@
         </div>
     {% endif %}
   {% endblock %}
-
-
   </div>
 </div>
 

--- a/catalog/templates/base_generic.html
+++ b/catalog/templates/base_generic.html
@@ -41,19 +41,24 @@
    <hr>
    <ul class="sidebar-nav">
    <li>Staff</li>
-   {% if perms.catalog.can_mark_returned %}
    <li><a href="{% url 'all-borrowed' %}">All borrowed</a></li>
-   <li><a href="{% url 'genre-create' %}">Create genre</a></li>
-   <li><a href="{% url 'language-create' %}">Create language</a></li>
-   <li><a href="{% url 'author-create' %}">Create author</a></li>
-   <li><a href="{% url 'book-create' %}">Create book</a></li>
-   <li><a href="{% url 'bookinstance-create' %}">create BookInstance</a></li>
+   {% if perms.catalog.add_genre %}
+     <li><a href="{% url 'genre-create' %}">Create genre</a></li>
    {% endif %}
-
-
-
+   {% if perms.catalog.add_genre %}
+     <li><a href="{% url 'language-create' %}">Create language</a></li>
+   {% endif %}
+   {% if perms.catalog.add_author %}
+     <li><a href="{% url 'author-create' %}">Create author</a></li>
+   {% endif %}
+   {% if perms.catalog.add_book %}
+     <li><a href="{% url 'book-create' %}">Create book</a></li>
+   {% endif %}
+   {% if perms.catalog.add_bookinstance %}
+     <li><a href="{% url 'bookinstance-create' %}">create BookInstance</a></li>
+   {% endif %}
    </ul>
-    {% endif %}
+   {% endif %} 
 
 {% endblock %}
   </div>

--- a/catalog/templates/base_generic.html
+++ b/catalog/templates/base_generic.html
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  
+
   {% block title %}<title>Local Library</title>{% endblock %}
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
 
-  
+
   <!-- Add additional CSS in static file -->
   {% load static %}
   <link rel="stylesheet" href="{% static 'css/styles.css' %}">
@@ -21,35 +21,46 @@
   {% block sidebar %}
   <ul class="sidebar-nav">
     <li><a href="{% url 'index' %}">Home</a></li>
+    <li><a href="{% url 'bookinstances' %}">All book copies</a></li>
     <li><a href="{% url 'books' %}">All books</a></li>
     <li><a href="{% url 'authors' %}">All authors</a></li>
+    <li><a href="{% url 'genres' %}">All genres</a></li>
+    <li><a href="{% url 'languages' %}">All languages</a></li>
   </ul>
- 
+
   <ul class="sidebar-nav">
    {% if user.is_authenticated %}
      <li>User: {{ user.get_username }}</li>
      <li><a href="{% url 'my-borrowed' %}">My Borrowed</a></li>
-     <li><a href="{% url 'logout'%}?next={{request.path}}">Logout</a></li>   
+     <li><a href="{% url 'logout'%}?next={{request.path}}">Logout</a></li>
    {% else %}
-     <li><a href="{% url 'login'%}?next={{request.path}}">Login</a></li>   
-   {% endif %} 
+     <li><a href="{% url 'login'%}?next={{request.path}}">Login</a></li>
+   {% endif %}
   </ul>
-  
+
    {% if user.is_staff %}
    <hr>
    <ul class="sidebar-nav">
    <li>Staff</li>
    {% if perms.catalog.can_mark_returned %}
    <li><a href="{% url 'all-borrowed' %}">All borrowed</a></li>
+   <li><a href="{% url 'genre-create' %}">Create Genre</a></li>
+   <li><a href="{% url 'language-create' %}">Create Language</a></li>
+   <li><a href="{% url 'author-create' %}">Create Author</a></li>
+   <li><a href="{% url 'book-create' %}">Create Book</a></li>
+   <li><a href="{% url 'bookinstance-create' %}">Create BookInstance</a></li>
    {% endif %}
+
+
+
    </ul>
     {% endif %}
- 
+
 {% endblock %}
   </div>
   <div class="col-sm-10 ">
   {% block content %}{% endblock %}
-  
+
   {% block pagination %}
     {% if is_paginated %}
         <div class="pagination">
@@ -66,9 +77,9 @@
             </span>
         </div>
     {% endif %}
-  {% endblock %} 
-  
-  
+  {% endblock %}
+
+
   </div>
 </div>
 

--- a/catalog/templates/catalog/author_confirm_delete.html
+++ b/catalog/templates/catalog/author_confirm_delete.html
@@ -4,11 +4,22 @@
 
 <h1>Delete Author: {{ author }}</h1>
 
+{% if author.book_set.all %}
+
+<p>You can't delete this author until all their books have been deleted:</p>
+<ul>
+  {% for book in author.book_set.all %}
+    <li><a href="{% url 'book-detail' book.pk %}">{{book}}</a> ({{book.bookinstance_set.all.count}})</li>
+  {% endfor %}
+</ul>
+
+{% else %}
 <p>Are you sure you want to delete the author?</p>
 
 <form action="" method="POST">
   {% csrf_token %}
   <input type="submit" action="" value="Yes, delete.">
 </form>
+{% endif %}
 
 {% endblock %}

--- a/catalog/templates/catalog/author_detail.html
+++ b/catalog/templates/catalog/author_detail.html
@@ -23,13 +23,15 @@
 {% block sidebar %}
   {{ block.super }}
 
-  {% if perms.catalog.can_mark_returned %}
+  {% if perms.catalog.change_author or perms.catalog.delete_author %}
   <hr>
   <ul class="sidebar-nav">
-    <li><a href="{% url 'author-update' author.id %}">Update Author</a></li>
-      {% if not author.book_set.all %}
-        <li><a href="{% url 'author-delete' author.id %}">Delete Author</a></li>
-      {% endif %}
+    {% if perms.catalog.change_author %}
+      <li><a href="{% url 'author-update' author.id %}">Update author</a></li>
+    {% endif %}
+    {% if not author.book_set.all and perms.catalog.delete_author %}
+      <li><a href="{% url 'author-delete' author.id %}">Delete author</a></li>
+    {% endif %}
     </ul>
   {% endif %}
 

--- a/catalog/templates/catalog/author_detail.html
+++ b/catalog/templates/catalog/author_detail.html
@@ -12,8 +12,25 @@
 {% for book in author.book_set.all %}
   <dt><a href="{% url 'book-detail' book.pk %}">{{book}}</a> ({{book.bookinstance_set.all.count}})</dt>
   <dd>{{book.summary}}</dd>
+  {% empty %}
+  <p>This author has no books.</p>
 {% endfor %}
 </dl>
 
 </div>
+{% endblock %}
+
+{% block sidebar %}
+  {{ block.super }}
+
+  {% if perms.catalog.can_mark_returned %}
+  <hr>
+  <ul class="sidebar-nav">
+    <li><a href="{% url 'author-update' author.id %}">Update Author</a></li>
+      {% if not author.book_set.all %}
+        <li><a href="{% url 'author-delete' author.id %}">Delete Author</a></li>
+      {% endif %}
+    </ul>
+  {% endif %}
+
 {% endblock %}

--- a/catalog/templates/catalog/author_form.html
+++ b/catalog/templates/catalog/author_form.html
@@ -8,6 +8,5 @@
     {{ form.as_table }}
     </table>
     <input type="submit" value="Submit">
-    
 </form>
 {% endblock %}

--- a/catalog/templates/catalog/book_confirm_delete.html
+++ b/catalog/templates/catalog/book_confirm_delete.html
@@ -4,11 +4,22 @@
 
 <h1>Delete Book</h1>
 
+{% if book.bookinstance_set.all %}
+<p>You can't delete this book until all copies have been deleted:</p>
+
+<ul>
+{% for copy in book.bookinstance_set.all %}
+  <li><a href="{{ copy.get_absolute_url }}">{{copy.id}}</a> (Imprint: {{copy.imprint}})</li>
+{% endfor %}
+</ul>
+
+{% else %}
 <p>Are you sure you want to delete the book: {{ book }}?</p>
 
 <form action="" method="POST">
   {% csrf_token %}
   <input type="submit" action="" value="Yes, delete.">
 </form>
+{% endif %}
 
 {% endblock %}

--- a/catalog/templates/catalog/book_detail.html
+++ b/catalog/templates/catalog/book_detail.html
@@ -6,21 +6,37 @@
 
 <p><strong>Author:</strong> <a href="{{ book.author.get_absolute_url }}">{{ book.author }}</a></p>
 <p><strong>Summary:</strong> {{ book.summary }}</p>
-<p><strong>ISBN:</strong> {{ book.isbn }}</p> 
-<p><strong>Language:</strong> {{ book.language }}</p>  
+<p><strong>ISBN:</strong> {{ book.isbn }}</p>
+<p><strong>Language:</strong> {{ book.language }}</p>
 <p><strong>Genre:</strong> {{ book.genre.all|join:", " }}</p>
 
 <div style="margin-left:20px;margin-top:20px">
 <h4>Copies</h4>
 
 {% for copy in book.bookinstance_set.all %}
-<hr>
-<p class="{% if copy.status == 'a' %}text-success{% elif copy.status == 'd' %}text-danger{% else %}text-warning{% endif %}">{{ copy.get_status_display }}</p>
-{% if copy.status != 'a' %}<p><strong>Due to be returned:</strong> {{copy.due_back}}</p>{% endif %}
-<p><strong>Imprint:</strong> {{copy.imprint}}</p>
-<p class="text-muted"><strong>Id:</strong> {{copy.id}}</p>
-
+  <hr>
+  <p class="{% if copy.status == 'a' %}text-success{% elif copy.status == 'd' %}text-danger{% else %}text-warning{% endif %}">{{ copy.get_status_display }}</p>
+  {% if copy.status != 'a' %}<p><strong>Due to be returned:</strong> {{copy.due_back}}</p>{% endif %}
+  <p><strong>Imprint:</strong> {{copy.imprint}}</p>
+  <p class="text-muted"><strong>Id:</strong> <a href="{{ copy.get_absolute_url }}">{{copy.id}}</a></p>
+{% empty %}
+  <p>The library has no copies of this book.</p>
 {% endfor %}
 </div>
 {% endblock %}
 
+
+{% block sidebar %}
+  {{ block.super }}
+
+  {% if perms.catalog.can_mark_returned %}
+  <hr>
+  <ul class="sidebar-nav">
+    <li><a href="{% url 'book-update' book.id %}">Update Book</a></li>
+      {% if not book.bookinstance_set.all %}
+        <li><a href="{% url 'book-delete' book.id %}">Delete Book</a></li>
+      {% endif %}
+    </ul>
+  {% endif %}
+
+{% endblock %}

--- a/catalog/templates/catalog/book_detail.html
+++ b/catalog/templates/catalog/book_detail.html
@@ -29,13 +29,15 @@
 {% block sidebar %}
   {{ block.super }}
 
-  {% if perms.catalog.can_mark_returned %}
+  {% if perms.catalog.change_book or perms.catalog.delete_book %}
   <hr>
   <ul class="sidebar-nav">
-    <li><a href="{% url 'book-update' book.id %}">Update Book</a></li>
-      {% if not book.bookinstance_set.all %}
-        <li><a href="{% url 'book-delete' book.id %}">Delete Book</a></li>
-      {% endif %}
+    {% if perms.catalog.change_book %}
+      <li><a href="{% url 'book-update' book.id %}">Update Book</a></li>
+    {% endif %}
+    {% if not book.bookinstance_set.all and perms.catalog.delete_book %}
+      <li><a href="{% url 'book-delete' book.id %}">Delete Book</a></li>
+    {% endif %}
     </ul>
   {% endif %}
 

--- a/catalog/templates/catalog/bookinstance_confirm_delete.html
+++ b/catalog/templates/catalog/bookinstance_confirm_delete.html
@@ -2,9 +2,9 @@
 
 {% block content %}
 
-<h1>Delete Author: {{ author }}</h1>
+<h1>Delete Book Copy: {{ bookinstance }}</h1>
 
-<p>Are you sure you want to delete the author?</p>
+<p>Are you sure you want to delete this copy of the book?</p>
 
 <form action="" method="POST">
   {% csrf_token %}

--- a/catalog/templates/catalog/bookinstance_detail.html
+++ b/catalog/templates/catalog/bookinstance_detail.html
@@ -1,0 +1,32 @@
+{% extends "base_generic.html" %}
+
+{% block content %}
+
+<h1>BookInstance: {{ bookinstance.book.title }}</h1>
+
+<p><strong>Author:</strong> <a href="{{ bookinstance.book.author.get_absolute_url }}">{{ bookinstance.book.author }}</a></p>
+
+<p><strong>Imprint:</strong> {{ bookinstance.imprint }}</p>
+<p><strong>Status:</strong> {{ bookinstance.get_status_display }} {% if bookinstance.status != 'a' %} (Due: {{bookinstance.due_back}}){% endif %}</p>
+
+<hr>
+<ul>
+  <li>
+    <a href="{{ bookinstance.book.get_absolute_url }}">All copies</a></p>
+  </li>
+</ul>
+{% endblock %}
+
+
+{% block sidebar %}
+  {{ block.super }}
+
+  {% if perms.catalog.can_mark_returned %}
+  <hr>
+  <ul class="sidebar-nav">
+    <li><a href="{% url 'bookinstance-update' bookinstance.id %}">Update BookInstance</a></li>
+    <li><a href="{% url 'bookinstance-delete' bookinstance.id %}">Delete BookInstance</a></li>
+  </ul>
+  {% endif %}
+
+{% endblock %}

--- a/catalog/templates/catalog/bookinstance_detail.html
+++ b/catalog/templates/catalog/bookinstance_detail.html
@@ -21,11 +21,15 @@
 {% block sidebar %}
   {{ block.super }}
 
-  {% if perms.catalog.can_mark_returned %}
+  {% if perms.catalog.change_bookinstance or perms.catalog.delete_bookinstance %}
   <hr>
   <ul class="sidebar-nav">
-    <li><a href="{% url 'bookinstance-update' bookinstance.id %}">Update BookInstance</a></li>
-    <li><a href="{% url 'bookinstance-delete' bookinstance.id %}">Delete BookInstance</a></li>
+    {% if perms.catalog.change_bookinstance %}
+      <li><a href="{% url 'bookinstance-update' bookinstance.id %}">Update BookInstance</a></li>
+    {% endif %}
+    {% if perms.catalog.delete_bookinstance %}
+      <li><a href="{% url 'bookinstance-delete' bookinstance.id %}">Delete BookInstance</a></li>
+    {% endif %}
   </ul>
   {% endif %}
 

--- a/catalog/templates/catalog/bookinstance_form.html
+++ b/catalog/templates/catalog/bookinstance_form.html
@@ -1,0 +1,13 @@
+{% extends "base_generic.html" %}
+
+{% block content %}
+
+<form action="" method="post">
+    {% csrf_token %}
+    <table>
+    {{ form.as_table }}
+    </table>
+    <input type="submit" value="Submit">
+    
+</form>
+{% endblock %}

--- a/catalog/templates/catalog/bookinstance_list.html
+++ b/catalog/templates/catalog/bookinstance_list.html
@@ -1,0 +1,16 @@
+{% extends "base_generic.html" %}
+
+{% block content %}
+    <h1>Book Copies in Library</h1>
+
+    <ul>
+      {% for bookinst in bookinstance_list %}
+      <li class="{% if bookinst.is_overdue %}text-danger{% endif %}">
+        <a href="{% url 'bookinstance-detail' bookinst.pk %}">{{bookinst.book.title}}</a> ({{ bookinst.due_back }}) {% if user.is_staff %}- {{ bookinst.borrower }}{% endif %} {% if perms.catalog.can_mark_returned %}- <a href="{% url 'renew-book-librarian' bookinst.id %}">Renew</a>  {% endif %}
+      </li>
+      {% empty %}
+      <li>There are no book copies available.</li>
+      {% endfor %}
+    </ul>
+
+{% endblock %}

--- a/catalog/templates/catalog/genre_confirm_delete.html
+++ b/catalog/templates/catalog/genre_confirm_delete.html
@@ -2,9 +2,9 @@
 
 {% block content %}
 
-<h1>Delete Author: {{ author }}</h1>
+<h1>Delete Genre: {{ genre }}</h1>
 
-<p>Are you sure you want to delete the author?</p>
+<p>Are you sure you want to delete the genre?</p>
 
 <form action="" method="POST">
   {% csrf_token %}

--- a/catalog/templates/catalog/genre_detail.html
+++ b/catalog/templates/catalog/genre_detail.html
@@ -1,0 +1,41 @@
+{% extends "base_generic.html" %}
+
+{% block content %}
+
+<h1>Genre: {{ genre.name }}</h1>
+
+<div style="margin-left:20px;margin-top:20px">
+<h4>Books in genre</h4>
+
+<ul>
+  {% for copy in genre.book_set.all %}
+  <li>
+    <a href="{{ copy.get_absolute_url }}">{{ copy.title }}</a> ({{copy.author}})
+  </li>
+  {% empty %}
+  <li>There are no books in this genre.</li>
+  {% endfor %}
+</ul>
+
+{% endblock %}
+
+
+{% block sidebar %}
+  {{ block.super }}
+
+  {% if perms.catalog.can_mark_returned %}
+  <hr>
+  <ul class="sidebar-nav">
+    <li><a href="{% url 'genre-update' genre.id %}">Update Genre</a></li>
+      {% if not genre.book_set.all %}
+        <li><a href="{% url 'genre-delete' genre.id %}">Delete Genre</a></li>
+      {% endif %}
+    </ul>
+  {% endif %}
+
+{% endblock %}
+
+
+
+
+

--- a/catalog/templates/catalog/genre_detail.html
+++ b/catalog/templates/catalog/genre_detail.html
@@ -34,8 +34,3 @@
   {% endif %}
 
 {% endblock %}
-
-
-
-
-

--- a/catalog/templates/catalog/genre_detail.html
+++ b/catalog/templates/catalog/genre_detail.html
@@ -23,13 +23,15 @@
 {% block sidebar %}
   {{ block.super }}
 
-  {% if perms.catalog.can_mark_returned %}
+  {% if perms.catalog.change_genre or perms.catalog.delete_genre %}
   <hr>
   <ul class="sidebar-nav">
+    {% if perms.catalog.change_genre %}
     <li><a href="{% url 'genre-update' genre.id %}">Update Genre</a></li>
-      {% if not genre.book_set.all %}
-        <li><a href="{% url 'genre-delete' genre.id %}">Delete Genre</a></li>
-      {% endif %}
+    {% endif %}
+    {% if not genre.book_set.all and perms.catalog.delete_genre %}
+      <li><a href="{% url 'genre-delete' genre.id %}">Delete Genre</a></li>
+    {% endif %}
     </ul>
   {% endif %}
 

--- a/catalog/templates/catalog/genre_form.html
+++ b/catalog/templates/catalog/genre_form.html
@@ -1,0 +1,13 @@
+{% extends "base_generic.html" %}
+
+{% block content %}
+
+<form action="" method="post">
+    {% csrf_token %}
+    <table>
+    {{ form.as_table }}
+    </table>
+    <input type="submit" value="Submit">
+
+</form>
+{% endblock %}

--- a/catalog/templates/catalog/genre_list.html
+++ b/catalog/templates/catalog/genre_list.html
@@ -1,0 +1,25 @@
+{% extends "base_generic.html" %}
+
+{% block content %}
+
+<h1>Genre List</h1>
+
+{% if genre_list %}
+  <ul>
+
+  {% for genre in genre_list %}
+    <li>
+      <a href="{{ genre.get_absolute_url }}">
+      {{ genre }}
+      </a>
+    </li>
+  {% endfor %}
+
+ </ul>
+{% else %}
+  <p>There are no genres available.</p>
+{% endif %}
+
+
+{% endblock %}
+

--- a/catalog/templates/catalog/language_confirm_delete.html
+++ b/catalog/templates/catalog/language_confirm_delete.html
@@ -2,9 +2,9 @@
 
 {% block content %}
 
-<h1>Delete Author: {{ author }}</h1>
+<h1>Delete Language: {{ language }}</h1>
 
-<p>Are you sure you want to delete the author?</p>
+<p>Are you sure you want to delete the language?</p>
 
 <form action="" method="POST">
   {% csrf_token %}

--- a/catalog/templates/catalog/language_detail.html
+++ b/catalog/templates/catalog/language_detail.html
@@ -23,13 +23,15 @@
 {% block sidebar %}
   {{ block.super }}
 
-  {% if perms.catalog.can_mark_returned %}
+  {% if perms.catalog.change_language or perms.catalog.delete_language %}
   <hr>
   <ul class="sidebar-nav">
-    <li><a href="{% url 'language-update' language.id %}">Update Language</a></li>
-      {% if not language.book_set.all %}
-        <li><a href="{% url 'language-delete' language.id %}">Delete Language</a></li>
-      {% endif %}
+    {% if perms.catalog.change_language %}
+      <li><a href="{% url 'language-update' language.id %}">Update Language</a></li>
+    {% endif %}
+    {% if not language.book_set.all and perms.catalog.delete_language %}
+      <li><a href="{% url 'language-delete' language.id %}">Delete Language</a></li>
+    {% endif %}
     </ul>
   {% endif %}
 

--- a/catalog/templates/catalog/language_detail.html
+++ b/catalog/templates/catalog/language_detail.html
@@ -34,8 +34,3 @@
   {% endif %}
 
 {% endblock %}
-
-
-
-
-

--- a/catalog/templates/catalog/language_detail.html
+++ b/catalog/templates/catalog/language_detail.html
@@ -1,0 +1,41 @@
+{% extends "base_generic.html" %}
+
+{% block content %}
+
+<h1>Language: {{ language.name }}</h1>
+
+<div style="margin-left:20px;margin-top:20px">
+<h4>Books in language</h4>
+
+<ul>
+  {% for copy in language.book_set.all %}
+  <li>
+    <a href="{{ copy.get_absolute_url }}">{{ copy.title }}</a>
+  </li>
+  {% empty %}
+  <li>There are no books in this language.</li>
+  {% endfor %}
+</ul>
+
+{% endblock %}
+
+
+{% block sidebar %}
+  {{ block.super }}
+
+  {% if perms.catalog.can_mark_returned %}
+  <hr>
+  <ul class="sidebar-nav">
+    <li><a href="{% url 'language-update' language.id %}">Update Language</a></li>
+      {% if not language.book_set.all %}
+        <li><a href="{% url 'language-delete' language.id %}">Delete Language</a></li>
+      {% endif %}
+    </ul>
+  {% endif %}
+
+{% endblock %}
+
+
+
+
+

--- a/catalog/templates/catalog/language_form.html
+++ b/catalog/templates/catalog/language_form.html
@@ -1,0 +1,13 @@
+{% extends "base_generic.html" %}
+
+{% block content %}
+
+<form action="" method="post">
+    {% csrf_token %}
+    <table>
+    {{ form.as_table }}
+    </table>
+    <input type="submit" value="Submit">
+
+</form>
+{% endblock %}

--- a/catalog/templates/catalog/language_list.html
+++ b/catalog/templates/catalog/language_list.html
@@ -1,0 +1,18 @@
+{% extends "base_generic.html" %}
+
+{% block content %}
+
+<h1>Language List</h1>
+
+<ul>
+  {% for language in language_list %}
+  <li>
+    <a href="{{ language.get_absolute_url }}">{{ language }}</a>
+  </li>
+  {% empty %}
+  <li>There are no languages available.</li>
+  {% endfor %}
+</ul>
+
+{% endblock %}
+

--- a/catalog/tests/test_views.py
+++ b/catalog/tests/test_views.py
@@ -332,7 +332,7 @@ class RenewBookInstancesViewTest(TestCase):
             reverse('renew-book-librarian', kwargs={'pk': test_uid}))
         self.assertEqual(response.status_code, 404)
 
-
+from django.contrib.contenttypes.models import ContentType
 class AuthorCreateViewTest(TestCase):
     """Test case for the AuthorCreate view (Created as Challenge)."""
 
@@ -346,8 +346,21 @@ class AuthorCreateViewTest(TestCase):
         test_user1.save()
         test_user2.save()
 
-        permission = Permission.objects.get(name='Set book as returned')
-        test_user2.user_permissions.add(permission)
+        content_typeBook = ContentType.objects.get_for_model(Book)
+
+        permAddBook = Permission.objects.get(
+            codename="add_book",
+            content_type=content_typeBook,
+        )
+
+        content_typeAuthor = ContentType.objects.get_for_model(Author)
+        permAddAuthor = Permission.objects.get(
+            codename="add_author",
+            content_type=content_typeAuthor,
+        )
+
+
+        test_user2.user_permissions.add(permAddBook, permAddAuthor)
         test_user2.save()
 
         # Create a book
@@ -384,7 +397,7 @@ class AuthorCreateViewTest(TestCase):
         response = self.client.get(reverse('author-create'))
         self.assertEqual(response.status_code, 200)
 
-        expected_initial_date = datetime.date(2020, 6, 11)
+        expected_initial_date = datetime.date(2023, 11, 11)
         response_date = response.context['form'].initial['date_of_death']
         response_date = datetime.datetime.strptime(
             response_date, "%d/%m/%Y").date()

--- a/catalog/tests/test_views.py
+++ b/catalog/tests/test_views.py
@@ -55,18 +55,22 @@ from catalog.models import BookInstance, Book, Genre, Language
 from django.contrib.auth import get_user_model
 User = get_user_model()
 
+
 class LoanedBookInstancesByUserListViewTest(TestCase):
 
     def setUp(self):
         # Create two users
-        test_user1 = User.objects.create_user(username='testuser1', password='1X<ISRUkw+tuK')
-        test_user2 = User.objects.create_user(username='testuser2', password='2HJ1vRV0Z&3iD')
+        test_user1 = User.objects.create_user(
+            username='testuser1', password='1X<ISRUkw+tuK')
+        test_user2 = User.objects.create_user(
+            username='testuser2', password='2HJ1vRV0Z&3iD')
 
         test_user1.save()
         test_user2.save()
 
         # Create a book
-        test_author = Author.objects.create(first_name='John', last_name='Smith')
+        test_author = Author.objects.create(
+            first_name='John', last_name='Smith')
         test_genre = Genre.objects.create(name='Fantasy')
         test_language = Language.objects.create(name='English')
         test_book = Book.objects.create(
@@ -95,10 +99,12 @@ class LoanedBookInstancesByUserListViewTest(TestCase):
 
     def test_redirect_if_not_logged_in(self):
         response = self.client.get(reverse('my-borrowed'))
-        self.assertRedirects(response, '/accounts/login/?next=/catalog/mybooks/')
+        self.assertRedirects(
+            response, '/accounts/login/?next=/catalog/mybooks/')
 
     def test_logged_in_uses_correct_template(self):
-        login = self.client.login(username='testuser1', password='1X<ISRUkw+tuK')
+        login = self.client.login(
+            username='testuser1', password='1X<ISRUkw+tuK')
         response = self.client.get(reverse('my-borrowed'))
 
         # Check our user is logged in
@@ -107,10 +113,12 @@ class LoanedBookInstancesByUserListViewTest(TestCase):
         self.assertEqual(response.status_code, 200)
 
         # Check we used correct template
-        self.assertTemplateUsed(response, 'catalog/bookinstance_list_borrowed_user.html')
+        self.assertTemplateUsed(
+            response, 'catalog/bookinstance_list_borrowed_user.html')
 
     def test_only_borrowed_books_in_list(self):
-        login = self.client.login(username='testuser1', password='1X<ISRUkw+tuK')
+        login = self.client.login(
+            username='testuser1', password='1X<ISRUkw+tuK')
         response = self.client.get(reverse('my-borrowed'))
 
         # Check our user is logged in
@@ -151,7 +159,8 @@ class LoanedBookInstancesByUserListViewTest(TestCase):
             copy.status = 'o'
             copy.save()
 
-        login = self.client.login(username='testuser1', password='1X<ISRUkw+tuK')
+        login = self.client.login(
+            username='testuser1', password='1X<ISRUkw+tuK')
         response = self.client.get(reverse('my-borrowed'))
 
         # Check our user is logged in
@@ -170,7 +179,8 @@ class LoanedBookInstancesByUserListViewTest(TestCase):
             copy.status = 'o'
             copy.save()
 
-        login = self.client.login(username='testuser1', password='1X<ISRUkw+tuK')
+        login = self.client.login(
+            username='testuser1', password='1X<ISRUkw+tuK')
         response = self.client.get(reverse('my-borrowed'))
 
         # Check our user is logged in
@@ -196,17 +206,20 @@ class RenewBookInstancesViewTest(TestCase):
 
     def setUp(self):
         # Create a user
-        test_user1 = User.objects.create_user(username='testuser1', password='1X<ISRUkw+tuK')
+        test_user1 = User.objects.create_user(
+            username='testuser1', password='1X<ISRUkw+tuK')
         test_user1.save()
 
-        test_user2 = User.objects.create_user(username='testuser2', password='2HJ1vRV0Z&3iD')
+        test_user2 = User.objects.create_user(
+            username='testuser2', password='2HJ1vRV0Z&3iD')
         test_user2.save()
         permission = Permission.objects.get(name='Set book as returned')
         test_user2.user_permissions.add(permission)
         test_user2.save()
 
         # Create a book
-        test_author = Author.objects.create(first_name='John', last_name='Smith')
+        test_author = Author.objects.create(
+            first_name='John', last_name='Smith')
         test_genre = Genre.objects.create(name='Fantasy')
         test_language = Language.objects.create(name='English')
         test_book = Book.objects.create(title='Book Title', summary='My book summary',
@@ -228,67 +241,83 @@ class RenewBookInstancesViewTest(TestCase):
                                                               due_back=return_date, borrower=test_user2, status='o')
 
     def test_redirect_if_not_logged_in(self):
-        response = self.client.get(reverse('renew-book-librarian', kwargs={'pk': self.test_bookinstance1.pk}))
+        response = self.client.get(
+            reverse('renew-book-librarian', kwargs={'pk': self.test_bookinstance1.pk}))
         # Manually check redirect (Can't use assertRedirect, because the redirect URL is unpredictable)
         self.assertEqual(response.status_code, 302)
         self.assertTrue(response.url.startswith('/accounts/login/'))
 
     def test_forbidden_if_logged_in_but_not_correct_permission(self):
-        login = self.client.login(username='testuser1', password='1X<ISRUkw+tuK')
-        response = self.client.get(reverse('renew-book-librarian', kwargs={'pk': self.test_bookinstance1.pk}))
+        login = self.client.login(
+            username='testuser1', password='1X<ISRUkw+tuK')
+        response = self.client.get(
+            reverse('renew-book-librarian', kwargs={'pk': self.test_bookinstance1.pk}))
         self.assertEqual(response.status_code, 403)
 
-
     def test_logged_in_with_permission_borrowed_book(self):
-        login = self.client.login(username='testuser2', password='2HJ1vRV0Z&3iD')
-        response = self.client.get(reverse('renew-book-librarian', kwargs={'pk': self.test_bookinstance2.pk}))
+        login = self.client.login(
+            username='testuser2', password='2HJ1vRV0Z&3iD')
+        response = self.client.get(
+            reverse('renew-book-librarian', kwargs={'pk': self.test_bookinstance2.pk}))
 
         # Check that it lets us login - this is our book and we have the right permissions.
         self.assertEqual(response.status_code, 200)
 
     def test_logged_in_with_permission_another_users_borrowed_book(self):
-        login = self.client.login(username='testuser2', password='2HJ1vRV0Z&3iD')
-        response = self.client.get(reverse('renew-book-librarian', kwargs={'pk': self.test_bookinstance1.pk}))
+        login = self.client.login(
+            username='testuser2', password='2HJ1vRV0Z&3iD')
+        response = self.client.get(
+            reverse('renew-book-librarian', kwargs={'pk': self.test_bookinstance1.pk}))
 
         # Check that it lets us login. We're a librarian, so we can view any users book
         self.assertEqual(response.status_code, 200)
 
     def test_uses_correct_template(self):
-        login = self.client.login(username='testuser2', password='2HJ1vRV0Z&3iD')
-        response = self.client.get(reverse('renew-book-librarian', kwargs={'pk': self.test_bookinstance1.pk}))
+        login = self.client.login(
+            username='testuser2', password='2HJ1vRV0Z&3iD')
+        response = self.client.get(
+            reverse('renew-book-librarian', kwargs={'pk': self.test_bookinstance1.pk}))
         self.assertEqual(response.status_code, 200)
 
         # Check we used correct template
         self.assertTemplateUsed(response, 'catalog/book_renew_librarian.html')
 
     def test_form_renewal_date_initially_has_date_three_weeks_in_future(self):
-        login = self.client.login(username='testuser2', password='2HJ1vRV0Z&3iD')
-        response = self.client.get(reverse('renew-book-librarian', kwargs={'pk': self.test_bookinstance1.pk}))
+        login = self.client.login(
+            username='testuser2', password='2HJ1vRV0Z&3iD')
+        response = self.client.get(
+            reverse('renew-book-librarian', kwargs={'pk': self.test_bookinstance1.pk}))
         self.assertEqual(response.status_code, 200)
 
         date_3_weeks_in_future = datetime.date.today() + datetime.timedelta(weeks=3)
-        self.assertEqual(response.context['form'].initial['renewal_date'], date_3_weeks_in_future)
+        self.assertEqual(
+            response.context['form'].initial['renewal_date'], date_3_weeks_in_future)
 
     def test_form_invalid_renewal_date_past(self):
-        login = self.client.login(username='testuser2', password='2HJ1vRV0Z&3iD')
+        login = self.client.login(
+            username='testuser2', password='2HJ1vRV0Z&3iD')
 
         date_in_past = datetime.date.today() - datetime.timedelta(weeks=1)
         response = self.client.post(reverse('renew-book-librarian', kwargs={'pk': self.test_bookinstance1.pk}),
                                     {'renewal_date': date_in_past})
         self.assertEqual(response.status_code, 200)
-        self.assertFormError(response.context['form'], 'renewal_date', 'Invalid date - renewal in past')
+        self.assertFormError(
+            response.context['form'], 'renewal_date', 'Invalid date - renewal in past')
 
     def test_form_invalid_renewal_date_future(self):
-        login = self.client.login(username='testuser2', password='2HJ1vRV0Z&3iD')
+        login = self.client.login(
+            username='testuser2', password='2HJ1vRV0Z&3iD')
 
         invalid_date_in_future = datetime.date.today() + datetime.timedelta(weeks=5)
         response = self.client.post(reverse('renew-book-librarian', kwargs={'pk': self.test_bookinstance1.pk}),
                                     {'renewal_date': invalid_date_in_future})
         self.assertEqual(response.status_code, 200)
-        self.assertFormError(response.context['form'], 'renewal_date', 'Invalid date - renewal more than 4 weeks ahead')
+        self.assertFormError(
+            response.context['form'], 'renewal_date', 'Invalid date - renewal more than 4 weeks ahead')
 
     def test_redirects_to_all_borrowed_book_list_on_success(self):
-        login = self.client.login(username='testuser2', password='2HJ1vRV0Z&3iD')
+        login = self.client.login(
+            username='testuser2', password='2HJ1vRV0Z&3iD')
         valid_date_in_future = datetime.date.today() + datetime.timedelta(weeks=2)
         response = self.client.post(reverse('renew-book-librarian', kwargs={'pk': self.test_bookinstance1.pk}),
                                     {'renewal_date': valid_date_in_future})
@@ -297,8 +326,10 @@ class RenewBookInstancesViewTest(TestCase):
     def test_HTTP404_for_invalid_book_if_logged_in(self):
         import uuid
         test_uid = uuid.uuid4()  # unlikely UID to match our bookinstance!
-        login = self.client.login(username='testuser2', password='2HJ1vRV0Z&3iD')
-        response = self.client.get(reverse('renew-book-librarian', kwargs={'pk': test_uid}))
+        login = self.client.login(
+            username='testuser2', password='2HJ1vRV0Z&3iD')
+        response = self.client.get(
+            reverse('renew-book-librarian', kwargs={'pk': test_uid}))
         self.assertEqual(response.status_code, 404)
 
 
@@ -307,8 +338,10 @@ class AuthorCreateViewTest(TestCase):
 
     def setUp(self):
         # Create a user
-        test_user1 = User.objects.create_user(username='testuser1', password='1X<ISRUkw+tuK')
-        test_user2 = User.objects.create_user(username='testuser2', password='2HJ1vRV0Z&3iD')
+        test_user1 = User.objects.create_user(
+            username='testuser1', password='1X<ISRUkw+tuK')
+        test_user2 = User.objects.create_user(
+            username='testuser2', password='2HJ1vRV0Z&3iD')
 
         test_user1.save()
         test_user2.save()
@@ -318,40 +351,48 @@ class AuthorCreateViewTest(TestCase):
         test_user2.save()
 
         # Create a book
-        test_author = Author.objects.create(first_name='John', last_name='Smith')
+        test_author = Author.objects.create(
+            first_name='John', last_name='Smith')
 
     def test_redirect_if_not_logged_in(self):
         response = self.client.get(reverse('author-create'))
-        self.assertRedirects(response, '/accounts/login/?next=/catalog/author/create/')
+        self.assertRedirects(
+            response, '/accounts/login/?next=/catalog/author/create/')
 
     def test_forbidden_if_logged_in_but_not_correct_permission(self):
-        login = self.client.login(username='testuser1', password='1X<ISRUkw+tuK')
+        login = self.client.login(
+            username='testuser1', password='1X<ISRUkw+tuK')
         response = self.client.get(reverse('author-create'))
         self.assertEqual(response.status_code, 403)
 
     def test_logged_in_with_permission(self):
-        login = self.client.login(username='testuser2', password='2HJ1vRV0Z&3iD')
+        login = self.client.login(
+            username='testuser2', password='2HJ1vRV0Z&3iD')
         response = self.client.get(reverse('author-create'))
         self.assertEqual(response.status_code, 200)
 
     def test_uses_correct_template(self):
-        login = self.client.login(username='testuser2', password='2HJ1vRV0Z&3iD')
+        login = self.client.login(
+            username='testuser2', password='2HJ1vRV0Z&3iD')
         response = self.client.get(reverse('author-create'))
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'catalog/author_form.html')
 
     def test_form_date_of_death_initially_set_to_expected_date(self):
-        login = self.client.login(username='testuser2', password='2HJ1vRV0Z&3iD')
+        login = self.client.login(
+            username='testuser2', password='2HJ1vRV0Z&3iD')
         response = self.client.get(reverse('author-create'))
         self.assertEqual(response.status_code, 200)
 
         expected_initial_date = datetime.date(2020, 6, 11)
         response_date = response.context['form'].initial['date_of_death']
-        response_date = datetime.datetime.strptime(response_date, "%d/%m/%Y").date()
+        response_date = datetime.datetime.strptime(
+            response_date, "%d/%m/%Y").date()
         self.assertEqual(response_date, expected_initial_date)
 
     def test_redirects_to_detail_view_on_success(self):
-        login = self.client.login(username='testuser2', password='2HJ1vRV0Z&3iD')
+        login = self.client.login(
+            username='testuser2', password='2HJ1vRV0Z&3iD')
         response = self.client.post(reverse('author-create'),
                                     {'first_name': 'Christian Name', 'last_name': 'Surname'})
         # Manually check redirect because we don't know what author was created

--- a/catalog/tests/test_views.py
+++ b/catalog/tests/test_views.py
@@ -280,7 +280,7 @@ class RenewBookInstancesViewTest(TestCase):
 
     def test_form_invalid_renewal_date_future(self):
         login = self.client.login(username='testuser2', password='2HJ1vRV0Z&3iD')
-        
+
         invalid_date_in_future = datetime.date.today() + datetime.timedelta(weeks=5)
         response = self.client.post(reverse('renew-book-librarian', kwargs={'pk': self.test_bookinstance1.pk}),
                                     {'renewal_date': invalid_date_in_future})

--- a/catalog/urls.py
+++ b/catalog/urls.py
@@ -38,3 +38,32 @@ urlpatterns += [
     path('book/<int:pk>/update/', views.BookUpdate.as_view(), name='book-update'),
     path('book/<int:pk>/delete/', views.BookDelete.as_view(), name='book-delete'),
 ]
+
+
+
+# Add URLConf to list, view, create, update, and delete genre
+urlpatterns += [
+    path('genres/', views.GenreListView.as_view(), name='genres'),
+    path('genre/<int:pk>', views.GenreDetailView.as_view(), name='genre-detail'),
+    path('genre/create/', views.GenreCreate.as_view(), name='genre-create'),
+    path('genre/<int:pk>/update/', views.GenreUpdate.as_view(), name='genre-update'),
+    path('genre/<int:pk>/delete/', views.GenreDelete.as_view(), name='genre-delete'),
+]
+
+# Add URLConf to list, view, create, update, and delete languages
+urlpatterns += [
+    path('languages/', views.LanguageListView.as_view(), name='languages'),
+    path('language/<int:pk>', views.LanguageDetailView.as_view(), name='language-detail'),
+    path('language/create/', views.LanguageCreate.as_view(), name='language-create'),
+    path('language/<int:pk>/update/', views.LanguageUpdate.as_view(), name='language-update'),
+    path('language/<int:pk>/delete/', views.LanguageDelete.as_view(), name='language-delete'),
+]
+
+# Add URLConf to list, view, create, update, and delete bookinstances
+urlpatterns += [
+    path('bookinstances/', views.BookInstanceListView.as_view(), name='bookinstances'),
+    path('bookinstance/<uuid:pk>', views.BookInstanceDetailView.as_view(), name='bookinstance-detail'),
+    path('bookinstance/create/', views.BookInstanceCreate.as_view(), name='bookinstance-create'),
+    path('bookinstance/<uuid:pk>/update/', views.BookInstanceUpdate.as_view(), name='bookinstance-update'),
+    path('bookinstance/<uuid:pk>/delete/', views.BookInstanceDelete.as_view(), name='bookinstance-delete'),
+]

--- a/catalog/urls.py
+++ b/catalog/urls.py
@@ -40,7 +40,6 @@ urlpatterns += [
 ]
 
 
-
 # Add URLConf to list, view, create, update, and delete genre
 urlpatterns += [
     path('genres/', views.GenreListView.as_view(), name='genres'),
@@ -53,17 +52,24 @@ urlpatterns += [
 # Add URLConf to list, view, create, update, and delete languages
 urlpatterns += [
     path('languages/', views.LanguageListView.as_view(), name='languages'),
-    path('language/<int:pk>', views.LanguageDetailView.as_view(), name='language-detail'),
+    path('language/<int:pk>', views.LanguageDetailView.as_view(),
+         name='language-detail'),
     path('language/create/', views.LanguageCreate.as_view(), name='language-create'),
-    path('language/<int:pk>/update/', views.LanguageUpdate.as_view(), name='language-update'),
-    path('language/<int:pk>/delete/', views.LanguageDelete.as_view(), name='language-delete'),
+    path('language/<int:pk>/update/',
+         views.LanguageUpdate.as_view(), name='language-update'),
+    path('language/<int:pk>/delete/',
+         views.LanguageDelete.as_view(), name='language-delete'),
 ]
 
 # Add URLConf to list, view, create, update, and delete bookinstances
 urlpatterns += [
     path('bookinstances/', views.BookInstanceListView.as_view(), name='bookinstances'),
-    path('bookinstance/<uuid:pk>', views.BookInstanceDetailView.as_view(), name='bookinstance-detail'),
-    path('bookinstance/create/', views.BookInstanceCreate.as_view(), name='bookinstance-create'),
-    path('bookinstance/<uuid:pk>/update/', views.BookInstanceUpdate.as_view(), name='bookinstance-update'),
-    path('bookinstance/<uuid:pk>/delete/', views.BookInstanceDelete.as_view(), name='bookinstance-delete'),
+    path('bookinstance/<uuid:pk>', views.BookInstanceDetailView.as_view(),
+         name='bookinstance-detail'),
+    path('bookinstance/create/', views.BookInstanceCreate.as_view(),
+         name='bookinstance-create'),
+    path('bookinstance/<uuid:pk>/update/',
+         views.BookInstanceUpdate.as_view(), name='bookinstance-update'),
+    path('bookinstance/<uuid:pk>/delete/',
+         views.BookInstanceDelete.as_view(), name='bookinstance-delete'),
 ]

--- a/catalog/views.py
+++ b/catalog/views.py
@@ -167,7 +167,7 @@ class AuthorUpdate(PermissionRequiredMixin, UpdateView):
 class AuthorDelete(PermissionRequiredMixin, DeleteView):
     model = Author
     success_url = reverse_lazy('authors')
-    permission_required = 'catalog._author'
+    permission_required = 'catalog.delete_author'
 
     def form_valid(self, form):
         try:

--- a/catalog/views.py
+++ b/catalog/views.py
@@ -199,6 +199,15 @@ class BookDelete(PermissionRequiredMixin, DeleteView):
     success_url = reverse_lazy('books')
     permission_required = 'catalog.can_mark_returned'
 
+    def form_valid(self, form):
+        print("you all suck")
+        try:
+            self.object.delete()
+            return HttpResponseRedirect(self.success_url)
+        except Exception as e:
+            return HttpResponseRedirect(
+                reverse("book-delete", kwargs={"pk": self.object.pk})
+            )
 
 class GenreCreate(PermissionRequiredMixin, CreateView):
     model = Genre

--- a/catalog/views.py
+++ b/catalog/views.py
@@ -200,7 +200,6 @@ class BookDelete(PermissionRequiredMixin, DeleteView):
     permission_required = 'catalog.can_mark_returned'
 
     def form_valid(self, form):
-        print("you all suck")
         try:
             self.object.delete()
             return HttpResponseRedirect(self.success_url)

--- a/catalog/views.py
+++ b/catalog/views.py
@@ -27,25 +27,22 @@ def index(request):
                  'num_visits': num_visits},
     )
 
-
 from django.views import generic
+
 
 class BookListView(generic.ListView):
     """Generic class-based view for a list of books."""
     model = Book
     paginate_by = 10
 
-
 class BookDetailView(generic.DetailView):
     """Generic class-based detail view for a book."""
     model = Book
-
 
 class AuthorListView(generic.ListView):
     """Generic class-based list view for a list of authors."""
     model = Author
     paginate_by = 10
-
 
 class AuthorDetailView(generic.DetailView):
     """Generic class-based detail view for an author."""
@@ -56,29 +53,24 @@ class GenreDetailView(generic.DetailView):
     """Generic class-based detail view for a genre."""
     model = Genre
 
-
 class GenreListView(generic.ListView):
     """Generic class-based list view for a list of genres."""
     model = Genre
     paginate_by = 10
 
-
 class LanguageDetailView(generic.DetailView):
     """Generic class-based detail view for a genre."""
     model = Language
-
 
 class LanguageListView(generic.ListView):
     """Generic class-based list view for a list of genres."""
     model = Language
     paginate_by = 10
 
-
 class BookInstanceListView(generic.ListView):
     """Generic class-based view for a list of books."""
     model = BookInstance
     paginate_by = 10
-
 
 class BookInstanceDetailView(generic.DetailView):
     """Generic class-based detail view for a book."""
@@ -99,9 +91,9 @@ class LoanedBooksByUserListView(LoginRequiredMixin, generic.ListView):
             .order_by('due_back')
         )
 
-
 # Added as part of challenge!
 from django.contrib.auth.mixins import PermissionRequiredMixin
+
 
 class LoanedBooksAllListView(PermissionRequiredMixin, generic.ListView):
     """Generic class-based view listing all books on loan. Only visible to users with can_mark_returned permission."""
@@ -113,13 +105,13 @@ class LoanedBooksAllListView(PermissionRequiredMixin, generic.ListView):
     def get_queryset(self):
         return BookInstance.objects.filter(status__exact='o').order_by('due_back')
 
-
 from django.shortcuts import get_object_or_404
 from django.http import HttpResponseRedirect
 from django.urls import reverse
 import datetime
 from django.contrib.auth.decorators import login_required, permission_required
 from catalog.forms import RenewBookForm
+
 
 @login_required
 @permission_required('catalog.can_mark_returned', raise_exception=True)
@@ -159,6 +151,7 @@ from django.views.generic.edit import CreateView, UpdateView, DeleteView
 from django.urls import reverse_lazy
 from .models import Author
 
+
 class AuthorCreate(PermissionRequiredMixin, CreateView):
     model = Author
     fields = ['first_name', 'last_name', 'date_of_birth', 'date_of_death']
@@ -178,8 +171,9 @@ class AuthorDelete(PermissionRequiredMixin, DeleteView):
     success_url = reverse_lazy('authors')
     permission_required = 'catalog.can_mark_returned'
 
-
 # Classes created for the forms challenge
+
+
 class BookCreate(PermissionRequiredMixin, CreateView):
     model = Book
     fields = ['title', 'author', 'summary', 'isbn', 'genre', 'language']
@@ -205,6 +199,7 @@ class BookDelete(PermissionRequiredMixin, DeleteView):
             return HttpResponseRedirect(
                 reverse("book-delete", kwargs={"pk": self.object.pk})
             )
+
 
 class GenreCreate(PermissionRequiredMixin, CreateView):
     model = Genre
@@ -244,7 +239,7 @@ class LanguageDelete(PermissionRequiredMixin, DeleteView):
 
 class BookInstanceCreate(PermissionRequiredMixin, CreateView):
     model = BookInstance
-    fields = ['book','imprint', 'due_back', 'borrower', 'status']
+    fields = ['book', 'imprint', 'due_back', 'borrower', 'status']
     permission_required = 'catalog.can_mark_returned'
 
 

--- a/catalog/views.py
+++ b/catalog/views.py
@@ -1,8 +1,20 @@
+from .models import Author
+from django.urls import reverse_lazy
+from django.views.generic.edit import CreateView, UpdateView, DeleteView
+from catalog.forms import RenewBookForm
+from django.contrib.auth.decorators import login_required, permission_required
+import datetime
+from django.urls import reverse
+from django.http import HttpResponseRedirect
+from django.shortcuts import get_object_or_404
+from django.contrib.auth.mixins import PermissionRequiredMixin
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.views import generic
 from django.shortcuts import render
 
 # Create your views here.
 
-from .models import Book, Author, BookInstance, Genre
+from .models import Book, Author, BookInstance, Genre, Language
 
 
 def index(request):
@@ -11,7 +23,8 @@ def index(request):
     num_books = Book.objects.all().count()
     num_instances = BookInstance.objects.all().count()
     # Available copies of books
-    num_instances_available = BookInstance.objects.filter(status__exact='a').count()
+    num_instances_available = BookInstance.objects.filter(
+        status__exact='a').count()
     num_authors = Author.objects.count()  # The 'all()' is implied by default.
 
     # Number of visits to this view, as counted in the session variable.
@@ -26,9 +39,6 @@ def index(request):
                  'num_instances_available': num_instances_available, 'num_authors': num_authors,
                  'num_visits': num_visits},
     )
-
-
-from django.views import generic
 
 
 class BookListView(generic.ListView):
@@ -53,7 +63,37 @@ class AuthorDetailView(generic.DetailView):
     model = Author
 
 
-from django.contrib.auth.mixins import LoginRequiredMixin
+class GenreDetailView(generic.DetailView):
+    """Generic class-based detail view for a genre."""
+    model = Genre
+
+
+class GenreListView(generic.ListView):
+    """Generic class-based list view for a list of genres."""
+    model = Genre
+    paginate_by = 10
+
+
+class LanguageDetailView(generic.DetailView):
+    """Generic class-based detail view for a genre."""
+    model = Language
+
+
+class LanguageListView(generic.ListView):
+    """Generic class-based list view for a list of genres."""
+    model = Language
+    paginate_by = 10
+
+
+class BookInstanceListView(generic.ListView):
+    """Generic class-based view for a list of books."""
+    model = BookInstance
+    paginate_by = 10
+
+
+class BookInstanceDetailView(generic.DetailView):
+    """Generic class-based detail view for a book."""
+    model = BookInstance
 
 
 class LoanedBooksByUserListView(LoginRequiredMixin, generic.ListView):
@@ -71,7 +111,6 @@ class LoanedBooksByUserListView(LoginRequiredMixin, generic.ListView):
 
 
 # Added as part of challenge!
-from django.contrib.auth.mixins import PermissionRequiredMixin
 
 
 class LoanedBooksAllListView(PermissionRequiredMixin, generic.ListView):
@@ -85,14 +124,7 @@ class LoanedBooksAllListView(PermissionRequiredMixin, generic.ListView):
         return BookInstance.objects.filter(status__exact='o').order_by('due_back')
 
 
-from django.shortcuts import get_object_or_404
-from django.http import HttpResponseRedirect
-from django.urls import reverse
-import datetime
-from django.contrib.auth.decorators import login_required, permission_required
-
 # from .forms import RenewBookForm
-from catalog.forms import RenewBookForm
 
 
 @login_required
@@ -129,11 +161,6 @@ def renew_book_librarian(request, pk):
     return render(request, 'catalog/book_renew_librarian.html', context)
 
 
-from django.views.generic.edit import CreateView, UpdateView, DeleteView
-from django.urls import reverse_lazy
-from .models import Author
-
-
 class AuthorCreate(PermissionRequiredMixin, CreateView):
     model = Author
     fields = ['first_name', 'last_name', 'date_of_birth', 'date_of_death']
@@ -143,7 +170,8 @@ class AuthorCreate(PermissionRequiredMixin, CreateView):
 
 class AuthorUpdate(PermissionRequiredMixin, UpdateView):
     model = Author
-    fields = '__all__' # Not recommended (potential security issue if more fields added)
+    # Not recommended (potential security issue if more fields added)
+    fields = '__all__'
     permission_required = 'catalog.can_mark_returned'
 
 
@@ -169,4 +197,59 @@ class BookUpdate(PermissionRequiredMixin, UpdateView):
 class BookDelete(PermissionRequiredMixin, DeleteView):
     model = Book
     success_url = reverse_lazy('books')
+    permission_required = 'catalog.can_mark_returned'
+
+
+class GenreCreate(PermissionRequiredMixin, CreateView):
+    model = Genre
+    fields = ['name', ]
+    permission_required = 'catalog.can_mark_returned'
+
+
+class GenreUpdate(PermissionRequiredMixin, UpdateView):
+    model = Genre
+    fields = ['name', ]
+    permission_required = 'catalog.can_mark_returned'
+
+
+class GenreDelete(PermissionRequiredMixin, DeleteView):
+    model = Genre
+    success_url = reverse_lazy('genres')
+    permission_required = 'catalog.can_mark_returned'
+
+
+class LanguageCreate(PermissionRequiredMixin, CreateView):
+    model = Language
+    fields = ['name', ]
+    permission_required = 'catalog.can_mark_returned'
+
+
+class LanguageUpdate(PermissionRequiredMixin, UpdateView):
+    model = Language
+    fields = ['name', ]
+    permission_required = 'catalog.can_mark_returned'
+
+
+class LanguageDelete(PermissionRequiredMixin, DeleteView):
+    model = Language
+    success_url = reverse_lazy('languages')
+    permission_required = 'catalog.can_mark_returned'
+
+
+class BookInstanceCreate(PermissionRequiredMixin, CreateView):
+    model = BookInstance
+    fields = ['book','imprint', 'due_back', 'borrower', 'status']
+    permission_required = 'catalog.can_mark_returned'
+
+
+class BookInstanceUpdate(PermissionRequiredMixin, UpdateView):
+    model = BookInstance
+    # fields = "__all__"
+    fields = ['imprint', 'due_back', 'borrower', 'status']
+    permission_required = 'catalog.can_mark_returned'
+
+
+class BookInstanceDelete(PermissionRequiredMixin, DeleteView):
+    model = BookInstance
+    success_url = reverse_lazy('bookinstances')
     permission_required = 'catalog.can_mark_returned'

--- a/catalog/views.py
+++ b/catalog/views.py
@@ -171,6 +171,15 @@ class AuthorDelete(PermissionRequiredMixin, DeleteView):
     success_url = reverse_lazy('authors')
     permission_required = 'catalog.can_mark_returned'
 
+    def form_valid(self, form):
+        try:
+            self.object.delete()
+            return HttpResponseRedirect(self.success_url)
+        except Exception as e:
+            return HttpResponseRedirect(
+                reverse("author-delete", kwargs={"pk": self.object.pk})
+            )
+
 # Classes created for the forms challenge
 
 

--- a/catalog/views.py
+++ b/catalog/views.py
@@ -1,21 +1,8 @@
-from .models import Author
-from django.urls import reverse_lazy
-from django.views.generic.edit import CreateView, UpdateView, DeleteView
-from catalog.forms import RenewBookForm
-from django.contrib.auth.decorators import login_required, permission_required
-import datetime
-from django.urls import reverse
-from django.http import HttpResponseRedirect
-from django.shortcuts import get_object_or_404
-from django.contrib.auth.mixins import PermissionRequiredMixin
-from django.contrib.auth.mixins import LoginRequiredMixin
-from django.views import generic
 from django.shortcuts import render
 
 # Create your views here.
 
 from .models import Book, Author, BookInstance, Genre, Language
-
 
 def index(request):
     """View function for home page of site."""
@@ -40,6 +27,8 @@ def index(request):
                  'num_visits': num_visits},
     )
 
+
+from django.views import generic
 
 class BookListView(generic.ListView):
     """Generic class-based view for a list of books."""
@@ -95,6 +84,7 @@ class BookInstanceDetailView(generic.DetailView):
     """Generic class-based detail view for a book."""
     model = BookInstance
 
+from django.contrib.auth.mixins import LoginRequiredMixin
 
 class LoanedBooksByUserListView(LoginRequiredMixin, generic.ListView):
     """Generic class-based view listing books on loan to current user."""
@@ -111,7 +101,7 @@ class LoanedBooksByUserListView(LoginRequiredMixin, generic.ListView):
 
 
 # Added as part of challenge!
-
+from django.contrib.auth.mixins import PermissionRequiredMixin
 
 class LoanedBooksAllListView(PermissionRequiredMixin, generic.ListView):
     """Generic class-based view listing all books on loan. Only visible to users with can_mark_returned permission."""
@@ -124,8 +114,12 @@ class LoanedBooksAllListView(PermissionRequiredMixin, generic.ListView):
         return BookInstance.objects.filter(status__exact='o').order_by('due_back')
 
 
-# from .forms import RenewBookForm
-
+from django.shortcuts import get_object_or_404
+from django.http import HttpResponseRedirect
+from django.urls import reverse
+import datetime
+from django.contrib.auth.decorators import login_required, permission_required
+from catalog.forms import RenewBookForm
 
 @login_required
 @permission_required('catalog.can_mark_returned', raise_exception=True)
@@ -160,6 +154,10 @@ def renew_book_librarian(request, pk):
 
     return render(request, 'catalog/book_renew_librarian.html', context)
 
+
+from django.views.generic.edit import CreateView, UpdateView, DeleteView
+from django.urls import reverse_lazy
+from .models import Author
 
 class AuthorCreate(PermissionRequiredMixin, CreateView):
     model = Author

--- a/catalog/views.py
+++ b/catalog/views.py
@@ -155,21 +155,19 @@ from .models import Author
 class AuthorCreate(PermissionRequiredMixin, CreateView):
     model = Author
     fields = ['first_name', 'last_name', 'date_of_birth', 'date_of_death']
-    initial = {'date_of_death': '11/06/2020'}
-    permission_required = 'catalog.can_mark_returned'
-
+    initial = {'date_of_death': '11/11/2023'}
+    permission_required = 'catalog.add_author'
 
 class AuthorUpdate(PermissionRequiredMixin, UpdateView):
     model = Author
     # Not recommended (potential security issue if more fields added)
     fields = '__all__'
-    permission_required = 'catalog.can_mark_returned'
-
+    permission_required = 'catalog.change_author'
 
 class AuthorDelete(PermissionRequiredMixin, DeleteView):
     model = Author
     success_url = reverse_lazy('authors')
-    permission_required = 'catalog.can_mark_returned'
+    permission_required = 'catalog._author'
 
     def form_valid(self, form):
         try:
@@ -186,19 +184,19 @@ class AuthorDelete(PermissionRequiredMixin, DeleteView):
 class BookCreate(PermissionRequiredMixin, CreateView):
     model = Book
     fields = ['title', 'author', 'summary', 'isbn', 'genre', 'language']
-    permission_required = 'catalog.can_mark_returned'
+    permission_required = 'catalog.add_book'
 
 
 class BookUpdate(PermissionRequiredMixin, UpdateView):
     model = Book
     fields = ['title', 'author', 'summary', 'isbn', 'genre', 'language']
-    permission_required = 'catalog.can_mark_returned'
+    permission_required = 'catalog.change_book'
 
 
 class BookDelete(PermissionRequiredMixin, DeleteView):
     model = Book
     success_url = reverse_lazy('books')
-    permission_required = 'catalog.can_mark_returned'
+    permission_required = 'catalog.delete_book'
 
     def form_valid(self, form):
         try:
@@ -213,53 +211,53 @@ class BookDelete(PermissionRequiredMixin, DeleteView):
 class GenreCreate(PermissionRequiredMixin, CreateView):
     model = Genre
     fields = ['name', ]
-    permission_required = 'catalog.can_mark_returned'
+    permission_required = 'catalog.add_genre'
 
 
 class GenreUpdate(PermissionRequiredMixin, UpdateView):
     model = Genre
     fields = ['name', ]
-    permission_required = 'catalog.can_mark_returned'
+    permission_required = 'catalog.change_genre'
 
 
 class GenreDelete(PermissionRequiredMixin, DeleteView):
     model = Genre
     success_url = reverse_lazy('genres')
-    permission_required = 'catalog.can_mark_returned'
+    permission_required = 'catalog.delete_genre'
 
 
 class LanguageCreate(PermissionRequiredMixin, CreateView):
     model = Language
     fields = ['name', ]
-    permission_required = 'catalog.can_mark_returned'
+    permission_required = 'catalog.add_language'
 
 
 class LanguageUpdate(PermissionRequiredMixin, UpdateView):
     model = Language
     fields = ['name', ]
-    permission_required = 'catalog.can_mark_returned'
+    permission_required = 'catalog.change_language'
 
 
 class LanguageDelete(PermissionRequiredMixin, DeleteView):
     model = Language
     success_url = reverse_lazy('languages')
-    permission_required = 'catalog.can_mark_returned'
+    permission_required = 'catalog.delete_language'
 
 
 class BookInstanceCreate(PermissionRequiredMixin, CreateView):
     model = BookInstance
     fields = ['book', 'imprint', 'due_back', 'borrower', 'status']
-    permission_required = 'catalog.can_mark_returned'
+    permission_required = 'catalog.add_bookinstance'
 
 
 class BookInstanceUpdate(PermissionRequiredMixin, UpdateView):
     model = BookInstance
     # fields = "__all__"
     fields = ['imprint', 'due_back', 'borrower', 'status']
-    permission_required = 'catalog.can_mark_returned'
+    permission_required = 'catalog.change_bookinstance'
 
 
 class BookInstanceDelete(PermissionRequiredMixin, DeleteView):
     model = BookInstance
     success_url = reverse_lazy('bookinstances')
-    permission_required = 'catalog.can_mark_returned'
+    permission_required = 'catalog.delete_bookinstance'

--- a/locallibrary/settings.py
+++ b/locallibrary/settings.py
@@ -21,10 +21,6 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 
 # SECURITY WARNING: keep the secret key used in production secret!
 # SECRET_KEY = 'django-insecure-&psk#na5l=p3q8_a+-$4w1f^lt3lx1c@d*p4x$ymm_rn7pwb87'
-<<<<<<< HEAD
-
-=======
->>>>>>> a608553 (Add settings 4.2 for dj url:)
 import os
 SECRET_KEY = os.environ.get('DJANGO_SECRET_KEY', 'django-insecure-&psk#na5l=p3q8_a+-$4w1f^lt3lx1c@d*p4x$ymm_rn7pwb87')
 

--- a/locallibrary/settings.py
+++ b/locallibrary/settings.py
@@ -21,7 +21,10 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 
 # SECURITY WARNING: keep the secret key used in production secret!
 # SECRET_KEY = 'django-insecure-&psk#na5l=p3q8_a+-$4w1f^lt3lx1c@d*p4x$ymm_rn7pwb87'
+<<<<<<< HEAD
 
+=======
+>>>>>>> a608553 (Add settings 4.2 for dj url:)
 import os
 SECRET_KEY = os.environ.get('DJANGO_SECRET_KEY', 'django-insecure-&psk#na5l=p3q8_a+-$4w1f^lt3lx1c@d*p4x$ymm_rn7pwb87')
 
@@ -151,15 +154,7 @@ STATIC_URL = '/static/'
 
 
 # Static file serving.
-<<<<<<< HEAD
-<<<<<<< HEAD
 # https://whitenoise.readthedocs.io/en/stable/django.html#add-compression-and-caching-support
-=======
-# http://whitenoise.evans.io/en/stable/django.html#django-middleware
->>>>>>> dc87cb8 (Minimal changes for 4.2 - inc use STORAGES)
-=======
-# https://whitenoise.readthedocs.io/en/stable/django.html#add-compression-and-caching-support
->>>>>>> 82dcc41 (Update requirements and fixup whitenoise link)
 STORAGES = {
     # ...
     "staticfiles": {

--- a/locallibrary/settings.py
+++ b/locallibrary/settings.py
@@ -20,7 +20,12 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/4.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
+<<<<<<< HEAD
 # SECRET_KEY = 'django-insecure-&psk#na5l=p3q8_a+-$4w1f^lt3lx1c@d*p4x$ymm_rn7pwb87'
+=======
+SECRET_KEY = 'django-insecure-&psk#na5l=p3q8_a+-$4w1f^lt3lx1c@d*p4x$ymm_rn7pwb87'
+
+>>>>>>> dc87cb8 (Minimal changes for 4.2 - inc use STORAGES)
 import os
 SECRET_KEY = os.environ.get('DJANGO_SECRET_KEY', 'django-insecure-&psk#na5l=p3q8_a+-$4w1f^lt3lx1c@d*p4x$ymm_rn7pwb87')
 
@@ -44,7 +49,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    # Add our new application 
+    # Add our new application
     'catalog.apps.CatalogConfig', #This object was created for us in /catalog/apps.py
 ]
 
@@ -149,8 +154,13 @@ STATIC_ROOT = BASE_DIR / 'staticfiles'  #. os.path.join(BASE_DIR, 'staticfiles')
 STATIC_URL = '/static/'
 
 
+
 # Static file serving.
+<<<<<<< HEAD
 # https://whitenoise.readthedocs.io/en/stable/django.html#add-compression-and-caching-support
+=======
+# http://whitenoise.evans.io/en/stable/django.html#django-middleware
+>>>>>>> dc87cb8 (Minimal changes for 4.2 - inc use STORAGES)
 STORAGES = {
     # ...
     "staticfiles": {

--- a/locallibrary/settings.py
+++ b/locallibrary/settings.py
@@ -20,12 +20,8 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/4.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-<<<<<<< HEAD
 # SECRET_KEY = 'django-insecure-&psk#na5l=p3q8_a+-$4w1f^lt3lx1c@d*p4x$ymm_rn7pwb87'
-=======
-SECRET_KEY = 'django-insecure-&psk#na5l=p3q8_a+-$4w1f^lt3lx1c@d*p4x$ymm_rn7pwb87'
 
->>>>>>> dc87cb8 (Minimal changes for 4.2 - inc use STORAGES)
 import os
 SECRET_KEY = os.environ.get('DJANGO_SECRET_KEY', 'django-insecure-&psk#na5l=p3q8_a+-$4w1f^lt3lx1c@d*p4x$ymm_rn7pwb87')
 
@@ -154,13 +150,16 @@ STATIC_ROOT = BASE_DIR / 'staticfiles'  #. os.path.join(BASE_DIR, 'staticfiles')
 STATIC_URL = '/static/'
 
 
-
 # Static file serving.
+<<<<<<< HEAD
 <<<<<<< HEAD
 # https://whitenoise.readthedocs.io/en/stable/django.html#add-compression-and-caching-support
 =======
 # http://whitenoise.evans.io/en/stable/django.html#django-middleware
 >>>>>>> dc87cb8 (Minimal changes for 4.2 - inc use STORAGES)
+=======
+# https://whitenoise.readthedocs.io/en/stable/django.html#add-compression-and-caching-support
+>>>>>>> 82dcc41 (Update requirements and fixup whitenoise link)
 STORAGES = {
     # ...
     "staticfiles": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Django==4.2.3
 dj-database-url==2.0.0
-gunicorn==21.2.3
+gunicorn==21.2.0
 psycopg2-binary==2.9.6
 wheel==0.38.1
 whitenoise==6.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,12 @@
 Django==4.2.3
 dj-database-url==2.0.0
+<<<<<<< HEAD
 gunicorn==21.2.0
 psycopg2-binary==2.9.3
 
+=======
+gunicorn==21.2.3
+psycopg2-binary==2.9.6
+>>>>>>> a608553 (Add settings 4.2 for dj url:)
 wheel==0.38.1
 whitenoise==6.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,6 @@
 Django==4.2.3
 dj-database-url==2.0.0
-<<<<<<< HEAD
-gunicorn==21.2.0
-psycopg2-binary==2.9.3
-
-=======
 gunicorn==21.2.3
 psycopg2-binary==2.9.6
->>>>>>> a608553 (Add settings 4.2 for dj url:)
 wheel==0.38.1
 whitenoise==6.5.0


### PR DESCRIPTION
Fixes #121
Fixes https://github.com/mdn/content/issues/27895

The tutorial finished too early so there was no testing of things through to bookinstances. What that meant was that if you deleted a book an exception would be raised.

This changes the examples so that you can only delete something if all its dependencies are deleted. I also added templates for all functionality so you can add, delete, update all objects via the UI. Upshot, should be easier to verify this kind of thing in future.

I also noted that much of the code relied on a custom permission, but add, delete, update operations have default permissions. So this uses them now for the view permission in forms and also for the template.

Tests were updated to match, but NOT to go all the way and test every new form.

Corresponding docs are in https://github.com/mdn/content/pull/30057

- [x] expanding example to allow create/delete/update/list for all types
- [x] Don't offer deletion of things in UI if there are dependencies
- [x] Prevent deletion in code by models if there are dependencies
