### PR TITLE
chore(ci): Add auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,12 @@
+name: auto-merge
+
+on:
+  pull_request_target:
+
+jobs:
+  auto-merge:
+    uses: mdn/workflows/.github/workflows/auto-merge.yml@main
+    with:
+      target-repo: "mdn/django-locallibrary-tutorial"
+    secrets:
+      GH_TOKEN: ${{ secrets.AUTOMERGE_TOKEN }}


### PR DESCRIPTION
### Description

This PR adds a workflow that automatically approves and squash merges PRs that bump minor deps if they are from dependabot.

For information, see https://github.com/mdn/workflows/blob/main/.github/workflows/auto-merge.yml


- [x] `AUTOMERGE_TOKEN` added to repository secrets with repo permissions