### PR TITLE
Fix incorrect load_dotenv usage in settings

### DIFF
--- a/locallibrary/settings.py
+++ b/locallibrary/settings.py
@@ -17,10 +17,15 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 
 
 # Add support for env variables from file if defined
-from dotenv import load_dotenv
 import os
-env_path = load_dotenv(os.path.join(BASE_DIR, '.env'))
-load_dotenv(env_path)
+from dotenv import load_dotenv
+
+env_file = os.path.join(BASE_DIR, ".env")
+
+# Load .env only if it exists
+if os.path.exists(env_file):
+    load_dotenv(env_file)
+
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/5.0/howto/deployment/checklist/

--- a/locallibrary/settings.py
+++ b/locallibrary/settings.py
@@ -26,7 +26,6 @@ env_file = os.path.join(BASE_DIR, ".env")
 if os.path.exists(env_file):
     load_dotenv(env_file)
 
-
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/5.0/howto/deployment/checklist/
 


### PR DESCRIPTION
### Description
This PR fixes an incorrect usage of `load_dotenv()` in `locallibrary/settings.py`.

Previously, `load_dotenv()` was treated as if it returned a file path, but it actually returns a boolean. The updated logic loads the `.env` file only if it exists.

### Motivation
This aligns the tutorial code with the actual behaviour of `python-dotenv` and avoids confusion or runtime warnings for learners following the Django deployment guide.

### Additional details
The fix uses `os.path.join` to remain consistent with the existing codebase and does not change any unrelated settings.

### Related issues and pull requests
Relates to mdn/content#42823


